### PR TITLE
Lazytime isoformat

### DIFF
--- a/defyes/lazytime.py
+++ b/defyes/lazytime.py
@@ -159,12 +159,10 @@ class Time(float):
     datetime, or string, using `repr_tz` as default timezone for representation.
     """
 
-    utc_format = "%Y-%m-%d %H:%M:%S"
-    general_format = "%Y-%m-%d %H:%M:%S %Z%z"
-
-    @property
-    def format(self):
-        return self.utc_format if repr_tz == timezone.utc else self.general_format
+    isoformat = {
+        "sep": " ",
+        "timespec": "auto",
+    }
 
     time_interval_class = Duration
     relative_time_class = RelativeTime
@@ -177,7 +175,8 @@ class Time(float):
         return repr(str(self))
 
     def __str__(self):
-        return self.calendar.strftime(self.format)
+        string = self.calendar.isoformat(**self.isoformat)
+        return string[:-6] if string.endswith("+00:00") else string
 
     @classmethod
     def from_calendar(
@@ -186,14 +185,12 @@ class Time(float):
         try:
             return cls(datetime(year, month, day, hour, minute, second, microsecond, tzinfo=tzinfo).timestamp())
         except TypeError:
-            return cls(datetime.strptime(year, cls.format).replace(tzinfo=timezone.utc).timestamp())
+            string = year
+            return cls.from_string(string)
 
     @classmethod
     def from_string(cls, string: str):
-        try:
-            dt = datetime.strptime(string, cls.utc_format)
-        except ValueError:
-            dt = datetime.strptime(string, cls.general_format)
+        dt = datetime.fromisoformat(string)
         if not dt.tzinfo:
             dt = dt.replace(tzinfo=timezone.utc)
         return cls(dt.timestamp())

--- a/tests/test_lazytime.py
+++ b/tests/test_lazytime.py
@@ -137,7 +137,7 @@ def test_time_calendar_just_change_representation(repr_tz_utc):
 def test_time_repr(repr_tz_utc):
     assert repr(Time(0)) == "'1970-01-01 00:00:00'"
     lazytime.repr_tz = lazytime.utc(2)
-    assert repr(Time(0)) == "'1970-01-01 02:00:00 UTC+0200'"
+    assert repr(Time(0)) == "'1970-01-01 02:00:00+02:00'"
 
 
 def test_time_from_calendar_is_always_utc_default(repr_tz_utc):
@@ -154,7 +154,7 @@ def test_time_from_calendar_different_tzinfo(repr_tz_utc):
 
 def test_time_from_string(repr_tz_utc):
     assert Time.from_string("1970-01-01 00:00:00") == 0
-    assert Time.from_string("1970-01-01 02:00:00 UTC+0200") == 0
+    assert Time.from_string("1970-01-01 02:00:00+02:00") == 0
 
 
 def test_time_from_string_invariant(repr_tz_utc):
@@ -163,7 +163,7 @@ def test_time_from_string_invariant(repr_tz_utc):
     """
     lazytime.repr_tz = lazytime.utc(2)
     assert Time.from_string("1970-01-01 00:00:00") == 0
-    assert Time.from_string("1970-01-01 02:00:00 UTC+0200") == 0
+    assert Time.from_string("1970-01-01 02:00:00+02:00") == 0
 
 
 def test_time_sub():


### PR DESCRIPTION
Using `isoformat` using `Time.isoformat` class level default, and `fromisoformat` because it's quite flexible to parse datetime strings (https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).

I also add `test_time_utc_is_default` to test the following:
```
    datetime tzinfo defaults to localtime depending on the TZ env var, but
    lazytime.Time doesn't depends on TZ, even doesn't depends on lazytime.repr_tz
```