### PR TITLE
Split karpatkit dependency into the optional-dependencies "all"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
+          pip install . 'defyes[all]'
 
       - name: Install development dependencies
         run: pip install -r requirements-dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install --upgrade pip \
 WORKDIR /repo
 
 COPY . /repo
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir . 'defyes[all]'
 RUN pip install --no-cache-dir -r requirements-dev.txt
 
 ENV PYTHONPATH /repo

--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ Some protocols supported: Aave v2 and v3, Lido, Compound v2 and v3, Balancer, Cu
 While cross-chain functionalities are supported, currently most integrations are focused on Ethereum
 and Gnosis Chain.
 
+## Install
+
+When using `defyes` as a library, you have two way to install it:
+```sh
+pip install . 'defyes[all]'
+```
+or, if you experiment dependencies conflicts, you can take control over some dependencies version by removing `[all]`
+but specifying each missing dependencie.
+```sh
+pip install . 'defyes'
+pip install "karpatkit @ git+https://github.com/karpatkey/karpatkit.git@another_specific_version"
+```
+where `another_specific_version` should be a git reference (tag, hash, branch).
+
+Have a look `all` in the [pyproject.toml](pyproject.toml) file, `[project.optional-dependencies]` section.
+
+> Take into account that installing just `defyes` without `defyes[all]` is an incompleted instalation.
+
+
 ## Configuration 
 
 - First you will have to copy, rename and modify the [config.json](https://github.com/karpatkey/defyes/blob/main/example_config.json)

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ and Gnosis Chain.
 
 ## Install
 
-When using `defyes` as a library, you have two way to install it:
+When using `defyes` as a library, you have two ways to install it:
 ```sh
 pip install . 'defyes[all]'
 ```
 or, if you experiment dependencies conflicts, you can take control over some dependencies version by removing `[all]`
-but specifying each missing dependencie.
+but specifying each missing dependency.
 ```sh
 pip install . 'defyes'
 pip install "karpatkit @ git+https://github.com/karpatkey/karpatkit.git@another_specific_version"
 ```
 where `another_specific_version` should be a git reference (tag, hash, branch).
 
-Have a look `all` in the [pyproject.toml](pyproject.toml) file, `[project.optional-dependencies]` section.
+Have a look at `all` in the [pyproject.toml](pyproject.toml) file, `[project.optional-dependencies]` section.
 
 > Take into account that installing just `defyes` without `defyes[all]` is an incompleted instalation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,15 @@ classifiers = [
 dependencies = [
     "diskcache>=5.4.0,<6.0",
     "eth_abi>=2.0.0",
-    "karpatkit @ git+https://github.com/karpatkey/karpatkit.git@e40513b28e17a3d2983582a80e49ee841083ea76",
     "requests>=2.28.1",
     "tqdm>=4.64.1",
     "web3>=6.3,<7.0",
     "gql>=3.4.0",
     "requests-toolbelt>=0.10.0"
+]
+[project.optional-dependencies]
+all = [ # Put here all dependencies with a strict version.
+    "karpatkit @ git+https://github.com/karpatkey/karpatkit.git@e40513b28e17a3d2983582a80e49ee841083ea76",
 ]
 
 [project.urls]


### PR DESCRIPTION
This is to have more flexibility when using this repo from another which has dependency conflicts.